### PR TITLE
Fix accesss_token typo

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -50,7 +50,7 @@ Cypress.Commands.add(
                 url: 'oauth/token',
                 method: 'POST',
                 response: {
-                    accesss_token: access_token,
+                    access_token: access_token,
                     id_token: id_token,
                     scope: "openid profile email",
                     expires_in: expires_in,


### PR DESCRIPTION
`accesss_token` has an extra "s" which was breaking logging in

Remove so it's `access_token`