### PR TITLE
Remove unnecessary 'then' before visit

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -69,9 +69,8 @@ Cypress.Commands.add(
                     "audience": "default",
                     "redirect_uri": "http://localhost:3000"
                 }))
-            ).then(() => {
-                cy.visit(`/?code=test-code&state=${stateId}`);
-            });
+            );
+            cy.visit(`/?code=test-code&state=${stateId}`);
         });
     }
 );


### PR DESCRIPTION
Cypress automatically queues all the commands and runs through them
one after another. So, there's no need for a 'then' as Cypress already
waits for the setCookie command to complete before the visit command.
https://docs.cypress.io/guides/core-concepts/introduction-to-cypress.html#Commands-Run-Serially